### PR TITLE
Adds CreatedOn Property to Run Class

### DIFF
--- a/TestRail/Types/Run.cs
+++ b/TestRail/Types/Run.cs
@@ -32,6 +32,9 @@ namespace TestRail.Types
         /// <summary>date on which the run which was completed</summary>
         public DateTime? CompletedOn { get; private set; }
 
+        /// <summary>date on which the run which was created</summary>
+        public DateTime CreatedOn { get; private set; }
+
         /// <summary>number of tests in the plan that passed</summary>
         public uint? PassedCount { get; private set; }
 
@@ -114,6 +117,7 @@ namespace TestRail.Types
                 Config = (string)json["config"],
                 IsCompleted = (bool?)json["is_completed"],
                 CompletedOn = ((null == (int?)json["completed_on"]) ? (DateTime?)null : new DateTime(1970, 1, 1).AddSeconds((int)json["completed_on"])),
+                CreatedOn = new DateTime(1970, 1, 1).AddSeconds((int)json["created_on"]),
                 PassedCount = (uint?)json["passed_count"],
                 BlockedCount = (uint?)json["blocked_count"],
                 UntestedCount = (uint?)json["untested_count"],


### PR DESCRIPTION
Noticed that this field was missing when I was looking for a way to filter testruns created today / this week / this month for our dashboards, So added it :smile: 

This PR:
- Adds the CreatedOn Property to the Run Class

![zappshot - 2016-06-16_02-16-25-pm](https://cloud.githubusercontent.com/assets/10059155/16118017/ed392d00-33cc-11e6-8769-9f98db5cad5f.png)

![zappshot - 2016-06-16_02-17-30-pm](https://cloud.githubusercontent.com/assets/10059155/16118050/12b18c26-33cd-11e6-8742-e7bde93dac53.png)