### PR TITLE
Fix error on JObject creation in RequestResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Solution was built using Visual Studio 2017 (make sure you have the latest versi
 - Run the unit tests from VS Test Explorer or by running `dotnet test TestRail.Tests\TestRail.Tests.csproj` from the root directory.
 
 ## Version History
+#### 3.1.2
+- Fix error on JObject creation in RequestResult
 #### 3.1.1
 - Fixed a bug with the client not being able to authenticate.
 - Added a testing project.

--- a/TestRail/TestRail.csproj
+++ b/TestRail/TestRail.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461;net45</TargetFrameworks>
     <PackageId>TestRail</PackageId>
-    <Version>3.1.1</Version>
+    <Version>3.1.2</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <Title>TestRail Client</Title>
     <Authors>TestRail Client Committers</Authors>

--- a/TestRail/Utils/RequestResult.cs
+++ b/TestRail/Utils/RequestResult.cs
@@ -64,7 +64,7 @@ namespace TestRail.Utils
                     }
                     else
                     {
-                        Payload = (T)staticConstructionMethod.Invoke(null, new object[] { new JObject(rawJson) });
+                        Payload = (T)staticConstructionMethod.Invoke(null, new object[] { JObject.Parse(rawJson) });
                     }
                 }
             }


### PR DESCRIPTION
Fix an issue when passing a string to JObject constructor instead of object raises exception "Can not add Newtonsoft.Json.Linq.JValue to Newtonsoft.Json.Linq.JObject."