### PR TITLE
Clarified parameter documentation for TestRailClient constructor

### DIFF
--- a/TestRail/TestRailClient.cs
+++ b/TestRail/TestRailClient.cs
@@ -36,8 +36,8 @@ namespace TestRail
         #region Constructor
         /// <summary>Constructor.</summary>
         /// <param name="baseUrl">Base URL for TestRail.</param>
-        /// <param name="userName">User name</param>
-        /// <param name="password">Password</param>
+        /// <param name="userName">User name.</param>
+        /// <param name="password">Password or API key.</param>
         public TestRailClient(string baseUrl, string userName, string password)
         {
             BaseUrl = baseUrl;


### PR DESCRIPTION
I was a little confused by #62, but as it turns out the [TestRail API](https://www.gurock.com/testrail/docs/api/getting-started/accessing/#Authentication) will accept two forms of authentication: `username:password` or `username:apikey`.

This is only a documentation change (I see no clean way to differentiate the calls from code).

This should resolve #62.